### PR TITLE
Fix bug where branch name includes a space after midnight.

### DIFF
--- a/clone-and-checkout.sh
+++ b/clone-and-checkout.sh
@@ -39,12 +39,12 @@ if [[ -z ${DPEBOT_GITHUB_TOKEN} ]] ; then
   exit 1
 fi
 
-BRANCH=latestdeps$(date +"%Y%m%d%k%M%S")
+BRANCH="repositorygardener$(date +"%Y%m%d")b${RANDOM}"
 
 # TODO: Support other orgs (such as codelabs).
 git clone "https://github.com/GoogleCloudPlatform/${REPO}.git" repo-to-update
 (
-cd repo-to-update
+cd repo-to-update || exit 1
 git config user.name "${DPEBOT_GIT_USER_NAME}"
 git config user.email "${DPEBOT_GIT_USER_EMAIL}"
 git remote add dpebot "https://dpebot:${DPEBOT_GITHUB_TOKEN}@github.com/dpebot/${REPO}.git"


### PR DESCRIPTION
In the AM hours, the 24-hour clock provided by %k in the date command
includes a space. This will use a random number instead.

Also, since more than just latestdeps can use the clone-and-checkout.sh
script, renames the branch to something more generic.