### PR TITLE
Push to a branch instead of a fork.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,23 @@ running tests to ensure they still work, send a Pull Request for the update.
 ## Example
 
 The following commands will clone the java-docs-samples repository and update
-its dependencies to the latest versions. (Assumes that java-repo-tools is
-already cloned to the `~/java-repo-tools` directory.)
+its dependencies to the latest versions.
+
+For Java, we need to also clone the `java-repo-tools` repository to get the
+latest version updater configuration.
 
 ```shell
 source set-env.sh \
   && git clone https://github.com/GoogleCloudPlatform/java-repo-tools.git
-  && ./clone-and-checkout.sh java-docs-samples \
+  && ./clone-and-checkout.sh -b dpebot-updatedeps GoogleCloudPlatform/java-docs-samples \
   && ( \
     cd repo-to-update \
-    && ../use-latest-deps-java.sh -d java-docs-samples
+    && ../use-latest-deps-java.sh -d GoogleCloudPlatform/java-docs-samples
  )
 ```
 
-Remove `-d` to actually push and send PR.
+The `-d` option in `use-latest-deps-java.sh` is to do a dry run (don't commit
+or push). Remove `-d` to actually push and send PR.
 
 ## Contributing changes
 

--- a/clone-and-checkout.sh
+++ b/clone-and-checkout.sh
@@ -39,15 +39,14 @@ if [[ -z ${DPEBOT_GITHUB_TOKEN} ]] ; then
   exit 1
 fi
 
-BRANCH="repositorygardener$(date +"%Y%m%d")b${RANDOM}"
+BRANCH="dpebot-repositorygardener"
 
 # TODO: Support other orgs (such as codelabs).
-git clone "https://github.com/GoogleCloudPlatform/${REPO}.git" repo-to-update
+git clone "https://dpebot:${DPEBOT_GITHUB_TOKEN}@github.com/GoogleCloudPlatform/${REPO}.git" repo-to-update
 (
 cd repo-to-update || exit 1
 git config user.name "${DPEBOT_GIT_USER_NAME}"
 git config user.email "${DPEBOT_GIT_USER_EMAIL}"
-git remote add dpebot "https://dpebot:${DPEBOT_GITHUB_TOKEN}@github.com/dpebot/${REPO}.git"
 
 git branch "$BRANCH" origin/master
 git checkout "$BRANCH"

--- a/clone-and-checkout.sh
+++ b/clone-and-checkout.sh
@@ -14,16 +14,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+print_usage() {
+  (>&2 echo "Usage:")
+  (>&2 echo "    $0 [-b branch-name] github-user/repository")
+}
+
+
+# Check for optional arguments.
+BRANCH="dpebot-repositorygardener"
+while getopts :b: opt; do
+  case $opt in
+    b)
+      BRANCH=$OPTARG
+      ;;
+    \?)
+      (>&2 echo "Got invalid option -$OPTARG.")
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+
+# Check that positional arguments are set.
 if [[ -z $1 ]] ; then
   (>&2 echo "Missing repo argument.")
-  (>&2 echo "Usage:")
-  (>&2 echo "    $0 repository-name")
-  (>&2 echo "Where repository-name is some repo under the GoogleCloudPlatform")
-  (>&2 echo "org with an identically-named fork.")
+  print_usage
+  exit 1
+fi
+if [[ "$1" != *"/"* ]] ; then
+  (>&2 echo "Repo argument needs to be of form username/repo-name.")
+  print_usage
   exit 1
 fi
 REPO=$1
 
+
+# Check that environment variables are set.
 if [[ -z ${DPEBOT_GIT_USER_NAME} ]] ; then
   (>&2 echo "DPEBOT_GIT_USER_NAME environment variable must be set.")
   exit 1
@@ -39,10 +67,8 @@ if [[ -z ${DPEBOT_GITHUB_TOKEN} ]] ; then
   exit 1
 fi
 
-BRANCH="dpebot-repositorygardener"
 
-# TODO: Support other orgs (such as codelabs).
-git clone "https://dpebot:${DPEBOT_GITHUB_TOKEN}@github.com/GoogleCloudPlatform/${REPO}.git" repo-to-update
+git clone "https://dpebot:${DPEBOT_GITHUB_TOKEN}@github.com/${REPO}.git" repo-to-update
 (
 cd repo-to-update || exit 1
 git config user.name "${DPEBOT_GIT_USER_NAME}"

--- a/commit-and-push.sh
+++ b/commit-and-push.sh
@@ -19,5 +19,5 @@
 BRANCH=$(git symbolic-ref --short HEAD)
 
 git commit -a -m "Auto-update dependencies."
-git push dpebot "$BRANCH"
+git push --force origin "$BRANCH"
 

--- a/send-pr.sh
+++ b/send-pr.sh
@@ -14,10 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ -z $1 ]] ; then
-  (>&2 echo "Missing repo argument.")
+print_usage() {
   (>&2 echo "Usage:")
   (>&2 echo "    $0 github-user-or-org/repository")
+}
+
+if [[ -z $1 ]] ; then
+  (>&2 echo "Missing repo argument.")
+  print_usage
+  exit 1
+fi
+if [[ "$1" != *"/"* ]] ; then
+  (>&2 echo "Repo argument needs to be of form username/repo-name.")
+  print_usage
   exit 1
 fi
 REPO=$1
@@ -36,7 +45,8 @@ curl -u "dpebot:${DPEBOT_GITHUB_TOKEN}" \
   -H "Content-Type: application/json" \
   -d "{
 \"title\": \"Auto-update dependencies.\",
-\"head\": \"dpebot:${BRANCH}\",
+\"body\": \"Brought to you by your friendly [Repository Gardener](https://github.com/GoogleCloudPlatform/repository-gardener).\",
+\"head\": \"${BRANCH}\",
 \"base\": \"master\" }" \
   "https://api.github.com/repos/${REPO}/pulls"
 

--- a/use-latest-deps-java.sh
+++ b/use-latest-deps-java.sh
@@ -16,13 +16,12 @@
 
 print_usage () {
   (>&2 echo "Usage:")
-  (>&2 echo "    $0 [-d] repository-name")
+  (>&2 echo "    $0 [-d] github-user/repository-name")
   (>&2 echo "Arguments:")
   (>&2 echo "    -d: do a dry-run. Don't push or send a PR.")
-  (>&2 echo "    repository-name: a repo under the GoogleCloudPlatform org")
-  (>&2 echo "                     with an identically-named fork.")
 }
 
+# Check for optional arguments.
 DRYRUN=0
 while getopts :d opt; do
   case $opt in
@@ -39,12 +38,20 @@ while getopts :d opt; do
 done
 shift $((OPTIND-1))
 
+
+# Check that positional arguments are set.
 if [[ -z $1 ]] ; then
   (>&2 echo "Missing repo argument.")
   print_usage
   exit 1
 fi
+if [[ "$1" != *"/"* ]] ; then
+  (>&2 echo "Repo argument needs to be of form username/repo-name.")
+  print_usage
+  exit 1
+fi
 REPO=$1
+
 
 # Get this script's directory.
 # http://stackoverflow.com/a/246128/101923
@@ -73,6 +80,6 @@ if [[ "$?" -ne 0 ]] ; then
   fi
 
   if [[ "$DRYRUN" -eq 0 ]] ; then
-    "${DIR}/send-pr.sh" "GoogleCloudPlatform/$REPO"
+    "${DIR}/send-pr.sh" "$REPO"
   fi
 fi

--- a/use-latest-deps-python.sh
+++ b/use-latest-deps-python.sh
@@ -16,13 +16,12 @@
 
 print_usage () {
   (>&2 echo "Usage:")
-  (>&2 echo "    $0 [-d] repository-name")
+  (>&2 echo "    $0 [-d] github-user/repository-name")
   (>&2 echo "Arguments:")
   (>&2 echo "    -d: do a dry-run. Don't push or send a PR.")
-  (>&2 echo "    repository-name: a repo under the GoogleCloudPlatform org")
-  (>&2 echo "                     with an identically-named fork.")
 }
 
+# Check for optional arguments.
 DRYRUN=0
 while getopts :d opt; do
   case $opt in
@@ -39,12 +38,20 @@ while getopts :d opt; do
 done
 shift $((OPTIND-1))
 
+
+# Check that positional arguments are set.
 if [[ -z $1 ]] ; then
   (>&2 echo "Missing repo argument.")
   print_usage
   exit 1
 fi
+if [[ "$1" != *"/"* ]] ; then
+  (>&2 echo "Repo argument needs to be of form username/repo-name.")
+  print_usage
+  exit 1
+fi
 REPO=$1
+
 
 # Get this script's directory.
 # http://stackoverflow.com/a/246128/101923
@@ -64,6 +71,6 @@ if [[ "$?" -ne 0 ]] ; then
   fi
 
   if [[ "$DRYRUN" -eq 0 ]] ; then
-    "${DIR}/send-pr.sh" "GoogleCloudPlatform/$REPO"
+    "${DIR}/send-pr.sh" "$REPO"
   fi
 fi


### PR DESCRIPTION
Many of our repos run integration / system tests on Travis. These
require access to credentials to run, so they must be run from a branch
instead of fork.

Also, so that we aren't creating a new branch every day, push to a
constant branch name instead of a new branch. (I forget why I wasn't
doing this in the first place.)

Example PR: https://github.com/GoogleCloudPlatform/java-docs-samples/pull/285