### PR TITLE
Update plugins for Java.

### DIFF
--- a/use-latest-deps-java.sh
+++ b/use-latest-deps-java.sh
@@ -59,9 +59,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 set -x
 
-mvn versions:use-latest-releases \
-  "-Dmaven.version.rules=file://$DIR/java-repo-tools/versions-rules.xml"
+# Update dependencies and plugins that use properties for version numbers.
+RULES_URI="file://$DIR/java-repo-tools/versions-rules.xml"
+mvn versions:use-latest-releases "-Dmaven.version.rules=$RULES_URI"
+mvn versions:update-properties "-Dmaven.version.rules=$RULES_URI"
 
+
+# If there were any changes, test them and then push and send a PR.
 git diff --quiet
 if [[ "$?" -ne 0 ]] ; then
   if [[ -e travis.sh ]] ; then


### PR DESCRIPTION
In order for the plugins to get updated by the Codehaus Maven Versions
plugin, the version numbers need to be set in properties. This will
update the properties when there are new versions for plugins.

@lesv FYI