### PR TITLE
Use default commit message

### DIFF
--- a/webhook-app/webhooks.py
+++ b/webhook-app/webhooks.py
@@ -143,7 +143,9 @@ def complete_merge_on_travis(data):
     for pull in pulls:
         # By supplying the sha here, it ensures that the PR will only be
         # merged if that sha is the HEAD of the branch.
-        pull.merge(sha=commit_sha, squash=True)
+        # commit_message is set to None to use a default commit messsage, 
+        # rather than an empty one.
+        pull.merge(sha=commit_sha, squash=True, commit_message=None)
 
         # Delete the branch if it's in this repo. ALSO DON'T DELETE MASTER.
         if (pull.head.ref != 'master' and


### PR DESCRIPTION
The library we use sets it to `''`, which means it's set to an empty commit message.
https://github.com/sigmavirus24/github3.py/blob/7ebca532da8dcc7f22be9f7f1b13fdea3e4d34c0/github3/pulls.py#L312-L331

If unset, GitHub will use a default message:
https://developer.github.com/v3/repos/merging/
