### PR TITLE
Revert "Use default commit message"

### DIFF
--- a/webhook-app/webhooks.py
+++ b/webhook-app/webhooks.py
@@ -143,9 +143,7 @@ def complete_merge_on_travis(data):
     for pull in pulls:
         # By supplying the sha here, it ensures that the PR will only be
         # merged if that sha is the HEAD of the branch.
-        # commit_message is set to None to use a default commit messsage, 
-        # rather than an empty one.
-        pull.merge(sha=commit_sha, squash=True, commit_message=None)
+        pull.merge(sha=commit_sha, squash=True)
 
         # Delete the branch if it's in this repo. ALSO DON'T DELETE MASTER.
         if (pull.head.ref != 'master' and


### PR DESCRIPTION
Reverts GoogleCloudPlatform/repository-gardener#16

Unfortunately the GitHub API doesn't accept a null value:

```
    An internal error occurred: <pre>422 Invalid request. For 'properties/commit_message', nil is not a string.</pre> See logs for full stacktrace.
```

Filing a bug upstream to add support for default commit messages.