### PR TITLE
Android builds for firebase/quickstart-android

### DIFF
--- a/.kokoro/build-android.sh
+++ b/.kokoro/build-android.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build script for repositories with Android dependencies.
+
+set -eo pipefail
+
+cd ${KOKORO_ARTIFACTS_DIR}/github/repository-gardener
+
+# Kokoro should set the following environment variables.
+# - DPEBOT_REPO
+# - DPEBOT_GIT_USER_NAME
+# - DPEBOT_GIT_USER_EMAIL="dpebot@google.com"
+# Kokoro exposes this as a file, but the scripts expect just a plain variable.
+export DPEBOT_GITHUB_TOKEN=$(cat ${KOKORO_GFILE_DIR}/${DPEBOT_GITHUB_TOKEN_FILE})
+
+chmod +x *.sh
+
+./clone-and-checkout.sh "${DPEBOT_REPO}"
+
+(
+cd repo-to-update
+../use-latest-deps-android.sh "${DPEBOT_REPO}"
+)

--- a/.kokoro/firebase/quickstart-android.cfg
+++ b/.kokoro/firebase/quickstart-android.cfg
@@ -1,0 +1,8 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "repository-gardener/.kokoro/build-android.sh"
+
+env_vars: {
+    key: "DPEBOT_REPO"
+    value: "firebase/quickstart-android"
+}


### PR DESCRIPTION
Because the android build script only calls python and `./gradlew` (which is self-contained) I don't think we should need any dependencies for Android checks.