### PR TITLE
Add check for required statuses.

### DIFF
--- a/webhook-app/github_helper.py
+++ b/webhook-app/github_helper.py
@@ -92,9 +92,9 @@ def get_pr_reviews(pr):
 def get_pr_required_statuses(pr):
     """Gets a list off all of the required statuses for a PR to be merged."""
     statuses = pr.session.get(
-        'https://api.github.com/repos/{}/branches/{}/protection/'
+        'https://api.github.com/repos/{}/{}/branches/{}/protection/'
         'required_status_checks/contexts'.format(
-            pr.repository, pr.base.ref)).json()
+            pr.repository[0], pr.repository[1], pr.base.ref)).json()
 
     return statuses
 
@@ -102,9 +102,9 @@ def get_pr_required_statuses(pr):
 def get_pr_statuses(pr):
     """Gets a list of currently reported statuses for the commit."""
     statuses = pr.session.get(
-        'https://api.github.com/repos/{}/commits/{}/'
+        'https://api.github.com/repos/{}/{}/commits/{}/'
         'statuses'.format(
-            pr.repository, pr.head.sha)).json()
+            pr.repository[0], pr.repository[1], pr.head.sha)).json()
 
     return [status['context'] for status in statuses]
 

--- a/webhook-app/github_helper.py
+++ b/webhook-app/github_helper.py
@@ -89,6 +89,39 @@ def get_pr_reviews(pr):
     return reviews
 
 
+def get_pr_required_statuses(pr):
+    """Gets a list off all of the required statuses for a PR to be merged."""
+    statuses = pr.session.get(
+        'https://api.github.com/repos/{}/branches/{}/protection/'
+        'required_status_checks/contexts'.format(
+            pr.repository, pr.base.ref)).json()
+
+    return statuses
+
+
+def get_pr_statuses(pr):
+    """Gets a list of currently reported statuses for the commit."""
+    statuses = pr.session.get(
+        'https://api.github.com/repos/{}/commits/{}/'
+        'statuses'.format(
+            pr.repository, pr.head.sha)).json()
+
+    return [status['context'] for status in statuses]
+
+
+def has_required_statuses(pr):
+    """Returns True if the PR has all the protected statuses present."""
+
+    required = get_pr_required_statuses(pr)
+
+    if not len(required):
+        return True
+
+    listed = get_pr_statuses(pr)
+
+    return set(required).issubset(set(listed))
+
+
 def is_pr_approved(pr):
     """True if the PR has been completely approved."""
     review_requests = get_pr_requested_reviewers(pr)

--- a/webhook-app/webhooks.py
+++ b/webhook-app/webhooks.py
@@ -183,6 +183,11 @@ def merge_pull_request(repo, pull, commit_sha=None):
         logging.info('Not merging {}, not labeled automerge'.format(pull))
         return
 
+    # only merge if all required status are reported
+    if not github_helper.has_required_statuses(pull):
+        logging.info('Not merging {}, missing required status')
+        return
+
     # only merge pulls that have all green statuses
     if not github_helper.is_sha_green(repo, commit_sha):
         logging.info('Not merging {}, not green.'.format(pull))

--- a/webhook-app/webhooks.py
+++ b/webhook-app/webhooks.py
@@ -185,7 +185,7 @@ def merge_pull_request(repo, pull, commit_sha=None):
 
     # only merge if all required status are reported
     if not github_helper.has_required_statuses(pull):
-        logging.info('Not merging {}, missing required status')
+        logging.info('Not merging {}, missing required status'.format(pull))
         return
 
     # only merge pulls that have all green statuses


### PR DESCRIPTION
This adds a check that all statuses are required by the protections on the branch are required to be reported before DPE bot merges a branch. This will help prevent accidental merges like https://github.com/GoogleCloudPlatform/java-docs-samples/pull/1049 when a required check hasn't started yet. 

[Protection API Reference](https://developer.github.com/v3/repos/branches/#get-required-status-checks-of-protected-branch)

I've tested the new functions locally to confirm that they work, but there is a difference between some of the syntax in the older functions. I was unable to get the following to work:
```python
'https://api.github.com/repos/{}/{}/pulls/{}/reviews'.format(
    pr.repository[0], pr.repository[1], pr.number),
```
and instead had to use:
```python
'https://api.github.com/repos/{}/pulls/{}/reviews'.format(
    pr.repository, pr.number),
```
I am not sure why this is, but suspected maybe a difference in library version. If you can clarify which is preferred for DPEbots environment, I can update to whatever works. 