### PR TITLE
Support for ncu config and yarn.lock

### DIFF
--- a/use-latest-deps-node.sh
+++ b/use-latest-deps-node.sh
@@ -88,12 +88,12 @@ for file in $files; do
   if [[ "$REGEX" == 0 ]]; then
     (
     cd "${FILE_DIR}"
-    $NODE_BIN/ncu -u -a;
+    "${NODE_BIN}/ncu" -u -a;
     )
   else
     (
     cd "${FILE_DIR}"
-    $NODE_BIN/ncu -u -a -f "${REGEX}";
+    "${NODE_BIN}/ncu" -u -a -f "${REGEX}";
     )
   fi
 
@@ -109,7 +109,7 @@ for file in $files; do
   if [ -f "${FILE_DIR}/yarn.lock" ]; then
     (
     cd "${FILE_DIR}"   
-    $NODE_BIN/yarn install --ignore-scripts --non-interactive
+    "${NODE_BIN}/yarn" install --ignore-scripts --non-interactive
     )
   fi
 done

--- a/use-latest-deps-node.sh
+++ b/use-latest-deps-node.sh
@@ -80,13 +80,17 @@ for file in $files; do
 
   # Move into the file's directory and run ncu, this auto-detects
   # the location of the package.json file and any .ncurc files
-  cd $FILE_DIR
   if [[ "$REGEX" == 0 ]]; then
+    (
+    cd "${FILE_DIR}"
     $NCU -u -a;
+    )
   else
+    (
+    cd "${FILE_DIR}"
     $NCU -u -a -f "${REGEX}";
+    )
   fi
-  cd -
 
   # If the folder contains a package-lock.json file then run `npm install` to also update the lock file.
   if [ -f "${FILE_DIR}/package-lock.json" ]; then

--- a/use-latest-deps-node.sh
+++ b/use-latest-deps-node.sh
@@ -69,20 +69,26 @@ set -e
 # Install the npm-check-updates package so we can use `ncu`. It is insalled in
 # the parent directory to avoid polluting the repo's package.json file.
 npm --prefix ../ install npm-check-updates
+NCU=$(pwd)/../node_modules/.bin/ncu
 
 # Find all package.json files.
 files=$(find . -name "package.json" -not -path "**/node_modules/*")
 
 # Update dependencies in all package.json files.
 for file in $files; do
+  FILE_DIR=$(dirname "${file}")
+
+  # Move into the file's directory and run ncu, this auto-detects
+  # the location of the package.json file and any .ncurc files
+  cd $FILE_DIR
   if [[ "$REGEX" == 0 ]]; then
-    ../node_modules/.bin/ncu -u -a --packageFile "${file}";
+    $NCU -u -a;
   else
-    ../node_modules/.bin/ncu -u -a -f "${REGEX}" --packageFile "${file}";
+    $NCU -u -a -f "${REGEX}";
   fi
+  cd -
 
   # If the folder contains a package-lock.json file then run `npm install` to also update the lock file.
-  FILE_DIR=$(dirname "${file}")
   if [ -f "${FILE_DIR}/package-lock.json" ]; then
     npm --prefix "$FILE_DIR" install --package-lock-only
   fi


### PR DESCRIPTION
### NCU Config

The `ncu` tool can detect an `.ncurc.json` file in the same directory as the `package.json`:
https://github.com/tjunnone/npm-check-updates#configuration-files

This allows repos using the gardener to configure their update preferences, like this:

```js
// Don't allow ncu to touch the firebase-admin dependency
{
    "upgrade": true,
    "reject": [
        "firebase-admin"
    ]
}
```

### Yarn Lock

If a `yarn.lock` file is detected then `yarn install` is run to regenerate it.

<hr />

Here's an example showing all the new features in action:
https://github.com/samtstern/firebase-js-sdk/pull/1/files