### PR TITLE
Accept Android SDK licenses

### DIFF
--- a/.kokoro/build-android.sh
+++ b/.kokoro/build-android.sh
@@ -20,6 +20,9 @@ else
   ./clone-and-checkout.sh -b "${DPEBOT_BRANCH}" "${DPEBOT_REPO}"
 fi
 
+# Accept Android SDK Licenses
+echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license"
+
 (
 cd repo-to-update
 ../use-latest-deps-android.sh "${DPEBOT_REPO}"


### PR DESCRIPTION
All of my android builds have been failing for a while:
![screenshot from 2019-02-25 08-20-50](https://user-images.githubusercontent.com/8466666/53351556-51520f80-38d6-11e9-852c-2e88cd65affa.png)

Here's the error I get:
```
* What went wrong:
A problem occurred configuring project ':admob:app'.
> Failed to install the following Android SDK packages as some licences have not been accepted.
     build-tools;28.0.3 Android SDK Build-Tools 28.0.3
  To build this project, accept the SDK license agreements and install the missing components using the Android Studio SDK Manager.
  Alternatively, to transfer the license agreements from one workstation to another, see http://d.android.com/r/studio-ui/export-licenses.html
  
  Using Android SDK: /opt/android-sdk/current
```