### PR TITLE
Make push section of node script easier to inspect

### DIFF
--- a/use-latest-deps-node.sh
+++ b/use-latest-deps-node.sh
@@ -117,10 +117,10 @@ done
 set +e
 if ! git diff --quiet; then
   if [[ "$DRYRUN" -eq 0 ]]; then
+    set -e
     "${DIR}/commit-and-push.sh"
-  fi
-
-  if [[ "$DRYRUN" -eq 0 ]]; then
     "${DIR}/send-pr.sh" "$REPO"
   fi
+else
+  "No 'git diff', nothing to push."
 fi


### PR DESCRIPTION
Two changes:
  * Enable `set -e` before pushing so that failure to push fails the build
  * Print a message if diff is empty