### PR TITLE
Make the node dependency regex an optional environment variable

### DIFF
--- a/.kokoro/firebase/build-node.sh
+++ b/.kokoro/firebase/build-node.sh
@@ -22,7 +22,7 @@ fi
 
 (
 cd repo-to-update
-if [[ -z "${NODE_REGEX}" ]]; then
+if [[ -z ${NODE_REGEX+x} ]]; then
   ../use-latest-deps-node.sh "${DPEBOT_REPO}"
 else
   ../use-latest-deps-node.sh -p "${NODE_REGEX}" "${DPEBOT_REPO}"

--- a/.kokoro/firebase/build-node.sh
+++ b/.kokoro/firebase/build-node.sh
@@ -22,7 +22,7 @@ fi
 
 (
 cd repo-to-update
-if [[ -z ${NODE_REGEX+x} ]]; then
+if [ -z ${NODE_REGEX+x} ]; then
   ../use-latest-deps-node.sh "${DPEBOT_REPO}"
 else
   ../use-latest-deps-node.sh -p "${NODE_REGEX}" "${DPEBOT_REPO}"

--- a/.kokoro/firebase/build-node.sh
+++ b/.kokoro/firebase/build-node.sh
@@ -22,6 +22,9 @@ fi
 
 (
 cd repo-to-update
-# Update Firebase Node dependencies only.
-../use-latest-deps-node.sh -p "/firebase.*/" "${DPEBOT_REPO}"
+if [[ -z "${NODE_REGEX}" ]]; then
+  ../use-latest-deps-node.sh "${DPEBOT_REPO}"
+else
+  ../use-latest-deps-node.sh -p "${NODE_REGEX}" "${DPEBOT_REPO}"
+fi
 )

--- a/.kokoro/firebase/friendlychat-web.cfg
+++ b/.kokoro/firebase/friendlychat-web.cfg
@@ -6,3 +6,8 @@ env_vars: {
     key: "DPEBOT_REPO"
     value: "firebase/friendlychat-web"
 }
+
+env_vars: {
+    key: "NODE_REGEX"
+    value: "/firebase.*/"
+}

--- a/.kokoro/firebase/friendlypix-web.cfg
+++ b/.kokoro/firebase/friendlypix-web.cfg
@@ -6,3 +6,8 @@ env_vars: {
     key: "DPEBOT_REPO"
     value: "firebase/friendlypix-web"
 }
+
+env_vars: {
+    key: "NODE_REGEX"
+    value: "/firebase.*/"
+}

--- a/.kokoro/firebase/functions-samples-node-Node-8.cfg
+++ b/.kokoro/firebase/functions-samples-node-Node-8.cfg
@@ -11,3 +11,8 @@ env_vars: {
     key: "DPEBOT_BRANCH"
     value: "Node-8"
 }
+
+env_vars: {
+    key: "NODE_REGEX"
+    value: "/firebase.*/"
+}

--- a/.kokoro/firebase/functions-samples.cfg
+++ b/.kokoro/firebase/functions-samples.cfg
@@ -6,3 +6,8 @@ env_vars: {
     key: "DPEBOT_REPO"
     value: "firebase/functions-samples"
 }
+
+env_vars: {
+    key: "NODE_REGEX"
+    value: "/firebase.*/"
+}

--- a/.kokoro/firebase/quickstart-js-node.cfg
+++ b/.kokoro/firebase/quickstart-js-node.cfg
@@ -6,3 +6,8 @@ env_vars: {
     key: "DPEBOT_REPO"
     value: "firebase/quickstart-js"
 }
+
+env_vars: {
+    key: "NODE_REGEX"
+    value: "/firebase.*/"
+}


### PR DESCRIPTION
The regex for "/firebase.*/" was hardcoded which is why the DPEBot was reporting a no-op on the Firebase JS SDK.

cc @Feiyang1