### PR TITLE
Add DPEBOT_ prefix to var so it is allowed

### DIFF
--- a/.kokoro/firebase/build-node.sh
+++ b/.kokoro/firebase/build-node.sh
@@ -22,9 +22,9 @@ fi
 
 (
 cd repo-to-update
-if [ -z ${NODE_REGEX+x} ]; then
+if [ -z ${DPEBOT_NODE_REGEX+x} ]; then
   ../use-latest-deps-node.sh "${DPEBOT_REPO}"
 else
-  ../use-latest-deps-node.sh -p "${NODE_REGEX}" "${DPEBOT_REPO}"
+  ../use-latest-deps-node.sh -p "${DPEBOT_NODE_REGEX}" "${DPEBOT_REPO}"
 fi
 )

--- a/.kokoro/firebase/friendlychat-web.cfg
+++ b/.kokoro/firebase/friendlychat-web.cfg
@@ -8,6 +8,6 @@ env_vars: {
 }
 
 env_vars: {
-    key: "NODE_REGEX"
+    key: "DPEBOT_NODE_REGEX"
     value: "/firebase.*/"
 }

--- a/.kokoro/firebase/friendlypix-web.cfg
+++ b/.kokoro/firebase/friendlypix-web.cfg
@@ -8,6 +8,6 @@ env_vars: {
 }
 
 env_vars: {
-    key: "NODE_REGEX"
+    key: "DPEBOT_NODE_REGEX"
     value: "/firebase.*/"
 }

--- a/.kokoro/firebase/functions-samples-node-Node-8.cfg
+++ b/.kokoro/firebase/functions-samples-node-Node-8.cfg
@@ -13,6 +13,6 @@ env_vars: {
 }
 
 env_vars: {
-    key: "NODE_REGEX"
+    key: "DPEBOT_NODE_REGEX"
     value: "/firebase.*/"
 }

--- a/.kokoro/firebase/functions-samples.cfg
+++ b/.kokoro/firebase/functions-samples.cfg
@@ -8,6 +8,6 @@ env_vars: {
 }
 
 env_vars: {
-    key: "NODE_REGEX"
+    key: "DPEBOT_NODE_REGEX"
     value: "/firebase.*/"
 }

--- a/.kokoro/firebase/quickstart-js-node.cfg
+++ b/.kokoro/firebase/quickstart-js-node.cfg
@@ -8,6 +8,6 @@ env_vars: {
 }
 
 env_vars: {
-    key: "NODE_REGEX"
+    key: "DPEBOT_NODE_REGEX"
     value: "/firebase.*/"
 }


### PR DESCRIPTION
In google3 there is a regex that says only `DPEBOT_` env variables are allowed.