### PR TITLE
Adds first repo for lib updates (many more to come).

### DIFF
--- a/.kokoro/android/common.cfg
+++ b/.kokoro/android/common.cfg
@@ -1,0 +1,18 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# The github token is stored here.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/dpebot"
+
+# Common env vars for all repositories and builds.
+env_vars: {
+    key: "DPEBOT_GITHUB_TOKEN_FILE"
+    value: "github-token.txt"
+}
+env_vars: {
+    key: "DPEBOT_GIT_USER_NAME"
+    value: "DPE bot"
+}
+env_vars: {
+    key: "DPEBOT_GIT_USER_EMAIL"
+    value: "dpebot@google.com"
+}

--- a/.kokoro/android/media-samples.cfg
+++ b/.kokoro/android/media-samples.cfg
@@ -1,0 +1,8 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "repository-gardener/.kokoro/build-android.sh"
+
+env_vars: {
+    key: "DPEBOT_REPO"
+    value: "android/media-samples"
+}


### PR DESCRIPTION
I wanted to separate all android samples so they don't pollute the top level directory (like firebase did).

I believe I still need the common.cfg from review the firebase sample. I will add more .cfg files for other repos once this one looks good. 

Let me know if you have any questions, thanks!