### PR TITLE
Support child projects android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ set-env.sh
 repo-to-update
 .idea/
 *.iml
+
+# Python
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ java-repo-tools
 set-env.sh
 repo-to-update
 .idea/
+*.iml

--- a/fix_android_dependencies.py
+++ b/fix_android_dependencies.py
@@ -24,7 +24,7 @@ GROUPS_ALLOWED_MAJOR_UPDATE = [
 #
 # Must run this command:
 # $ ./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json
-RELATIVE_PATH_TO_JSON_REPORT = '/build/dependencyUpdates/report.json'
+RELATIVE_PATH_TO_JSON_REPORT = 'build/dependencyUpdates/report.json'
 
 def find_gradle_files():
     """Finds all build.gradle files, recursively."""
@@ -113,7 +113,7 @@ def update_all():
     project_root = os.getcwd()
     print 'Repo root: {}'.format(project_root)
 
-    top_level_report = project_root + RELATIVE_PATH_TO_JSON_REPORT
+    top_level_report = os.path.join(project_root, RELATIVE_PATH_TO_JSON_REPORT)
 
     if os.path.exists(top_level_report):
         print 'Update dependencies via top-level report'
@@ -125,7 +125,7 @@ def update_all():
 
         for subdirectory in first_level_subdirectories:
             print 'subdirectory: {}'.format(subdirectory)
-            subdirectory_report = project_root + subdirectory + RELATIVE_PATH_TO_JSON_REPORT
+            subdirectory_report = os.path.join(project_root, subdirectory, RELATIVE_PATH_TO_JSON_REPORT)
 
             if os.path.exists(subdirectory_report):
                 print '\tUpdate dependencies in subdirectory'

--- a/fix_android_dependencies.py
+++ b/fix_android_dependencies.py
@@ -6,13 +6,14 @@ import re
 # easy way to determine the latest version.
 COMPILE_SDK_VERSION = 29
 TARGET_SDK_VERSION = 29
-BUILD_TOOLS_VERSION = '29.0.0'
+BUILD_TOOLS_VERSION = '29.0.2'
 
 COMPILE_SDK_RE = r'compileSdkVersion[\s][\w]+'
 TARGET_SDK_RE = r'targetSdkVersion[\s][\w]+'
 BUILD_TOOLS_RE = r'buildToolsVersion[\s][\'\"\w\.]+'
 
 GROUPS_ALLOWED_MAJOR_UPDATE = [
+  'androidx',
   'com.google.android.gms',
   'com.google.firebase',
   'com.android.support',
@@ -23,7 +24,7 @@ GROUPS_ALLOWED_MAJOR_UPDATE = [
 #
 # Must run this command:
 # $ ./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json
-INPUT_JSON = 'build/dependencyUpdates/report.json'
+RELATIVE_PATH_TO_JSON_REPORT = '/build/dependencyUpdates/report.json'
 
 def find_gradle_files():
     """Finds all build.gradle files, recursively."""
@@ -56,10 +57,10 @@ def is_major_update(old_version, new_version):
 
     return old_major != new_major
 
-def get_dep_replacements():
+def get_dep_replacements(json_file):
     """Gets a dictionary of all dependency replacements to be made."""
     replacements = {}
-    with open(INPUT_JSON, 'r') as f:
+    with open(json_file, 'r') as f:
         json_data = json.loads(f.read())
 
         outdated_deps = json_data['outdated']['dependencies']
@@ -70,10 +71,9 @@ def get_dep_replacements():
             curr_version = dep['version']
             new_version = dep['available']['release']
 
-            if (is_major_update(curr_version, new_version) and
-                group not in GROUPS_ALLOWED_MAJOR_UPDATE):
-              print 'Skipping major update to {}:{}'.format(group, name)
-              continue
+            if (is_major_update(curr_version, new_version) and group not in GROUPS_ALLOWED_MAJOR_UPDATE):
+                print 'Skipping major update to {}:{}'.format(group, name)
+                continue
 
             curr_dep = '{}:{}:{}'.format(group, name, curr_version)
             new_dep = '{}:{}:{}'.format(group, name, new_version)
@@ -81,11 +81,11 @@ def get_dep_replacements():
 
     return replacements
 
-def update_all():
-    """Runs through all build.gradle files and performs replacements."""
+def update_project(project_path):
+    """Runs through all build.gradle files and performs replacements for individual android project."""
     replacements = {}
     replacements.update(get_android_replacements())
-    replacements.update(get_dep_replacements())
+    replacements.update(get_dep_replacements(project_path))
 
     # Print all updates found
     print 'Dependency updates:'
@@ -107,5 +107,35 @@ def update_all():
         with open(gradle_file, 'w') as f:
             f.write(new_data)
 
+def update_all():
+    """Runs through all build.gradle files and performs replacements."""
+
+    project_root = os.getcwd()
+    print 'Repo root: {}'.format(project_root)
+
+    top_level_report = project_root + RELATIVE_PATH_TO_JSON_REPORT
+
+    if os.path.exists(top_level_report):
+        print 'Update dependencies via top-level report'
+        update_project(top_level_report)
+    else:
+        print 'Update dependencies via child-level report(s)'
+        first_level_subdirectories = get_immediate_subdirectories(project_root)
+        print 'List of subdirectories: {}'.format(first_level_subdirectories)
+
+        for subdirectory in first_level_subdirectories:
+            print 'subdirectory: {}'.format(subdirectory)
+            subdirectory_report = project_root + subdirectory + RELATIVE_PATH_TO_JSON_REPORT
+
+            if os.path.exists(subdirectory_report):
+                print '\tUpdate dependencies in subdirectory'
+                update_project(subdirectory_report)
+            else:
+                print '\tNo report in subdirectory'
+
+def get_immediate_subdirectories(directory):
+    return [name for name in os.listdir(directory)
+            if os.path.isdir(os.path.join(directory, name)) and not name.startswith('.')]
+
 if __name__ == '__main__':
-  update_all()
+    update_all()

--- a/use-latest-deps-android.sh
+++ b/use-latest-deps-android.sh
@@ -21,7 +21,7 @@ print_usage () {
   (>&2 echo "    -d: do a dry-run. Don't push or send a PR.")
 }
 
-update_android_dependencies () {
+generate_dependencies_report () {
   variables_passed=$#
 
   if [ $variables_passed -gt 0 ]; then
@@ -29,44 +29,25 @@ update_android_dependencies () {
 
     (>&2 echo "=========================================================================")
     (>&2 echo "Push sample path to run gradle command locally (NEW PATH, PREVIOUS PATH):")
-
     pushd "$dir"
 
     # Generate JSON dependencies report
-    # TODO: Fix this
-    #./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json
-    ./gradlew assembleDebug
+    ./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json
+
     gradle_exit_code="$?"
 
-    # General catchall error code.
-    fix_android_dependencies_exit_code=1
-
-    # Successful exit code means we can update the dependencies.
-    if [ $gradle_exit_code -eq 0 ]; then
-      fix_android_dependencies "${dir}"
-      fix_android_dependencies_exit_code="$?"
-    fi
-
     (>&2 echo "Pop sample path off stack, back to original path:")
-
     popd
 
-    if [ $gradle_exit_code -ne 0 ]; then
-      return $gradle_exit_code
+    return $gradle_exit_code
 
-    elif [ $fix_android_dependencies_exit_code -ne 0 ]; then
-      return $fix_android_dependencies_exit_code
-
-    else
-      return 0
-    fi
   else
     # Return invalid arguments exit code.
     return 128
   fi
 }
 
-fix_android_dependencies () {
+update_dependencies () {
   variables_passed=$#
 
   if [ $variables_passed -gt 0 ]; then
@@ -78,7 +59,7 @@ fix_android_dependencies () {
     source env/bin/activate
 
     # Run Android fixer script
-    python "${dir}/fix_android_dependencies.py"
+    python "${dir}/update_dependencies.py"
 
     # Remove the virtualenv
     rm -rf env
@@ -129,23 +110,27 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set +e
 set -x
 
-update_android_dependencies "${DIR}/"
-update_gradle_exit_code="$?"
+generate_dependencies_report "${DIR}/"
+generate_dependencies_report_exit_code="$?"
 
-# Gradle doesn't exist at root (127 means command not found), so we check all child folders for android/gradle projects.
-if [ $update_gradle_exit_code -eq 127 ]; then
-   (>&2 echo "No Gradle at root of repo, go one level deeper for samples.")
+# Gradle doesn't exist at root (127 means command not found), check all child folders for android/gradle projects.
+if [ $generate_dependencies_report_exit_code -eq 127 ]; then
+  (>&2 echo "No Gradle at root of repo, go one level deeper for samples.")
 
-   # Allows us to skip the loop if there aren't any folders.
-   shopt -s nullglob
+  # Allows us to skip the loop if there aren't any folders.
+  shopt -s nullglob
 
-   array=(*/)
+  # Generate list of folders in current directory.
+  child_dirs=(*/)
 
-   for child_dir in "${array[@]}"
-   do
-     update_android_dependencies "${DIR}/${child_dir}"
-   done
+  for child_dir in "${child_dirs[@]}"
+    do
+      generate_dependencies_report "${DIR}/${child_dir}"
+    done
 fi
+
+set -e
+update_dependencies "${DIR}"
 
 # If there were any changes, test them and then push and send a PR.
 if ! git diff --quiet; then


### PR DESCRIPTION
Includes both shell (previously reviewed) and now python side to update dependencies.

The python code works, but I'm not a python expert. I did have someone who knows python look over parts of the changes, but I would like a deep review to make sure it looks/reads ok.

Please note, Android basically moved support libs to android x, so I added 'androidx' to GROUPS_ALLOWED_MAJOR_UPDATE. Let me know if that is too general. I don't think it is, as we want our samples to use the latest major updates or break (so we can fix). 