### PR TITLE
Update friendlychat-android repo

### DIFF
--- a/.kokoro/firebase/codelab-friendlychat-android.cfg
+++ b/.kokoro/firebase/codelab-friendlychat-android.cfg
@@ -4,5 +4,5 @@ build_file: "repository-gardener/.kokoro/build-android.sh"
 
 env_vars: {
     key: "DPEBOT_REPO"
-    value: "codelab-firebase/friendlychat-android"
+    value: "firebase/codelab-friendlychat-android"
 }

--- a/.kokoro/firebase/codelab-friendlychat-android.cfg
+++ b/.kokoro/firebase/codelab-friendlychat-android.cfg
@@ -4,5 +4,5 @@ build_file: "repository-gardener/.kokoro/build-android.sh"
 
 env_vars: {
     key: "DPEBOT_REPO"
-    value: "firebase/friendlychat-android"
+    value: "codelab-firebase/friendlychat-android"
 }


### PR DESCRIPTION
The friendlychat-android repo has been renamed to codelab-friendlychat-android. This change points to the updated repo.