### PR TITLE
update friendly chat web repo

### DIFF
--- a/.kokoro/firebase/codelab-friendlychat-web.cfg
+++ b/.kokoro/firebase/codelab-friendlychat-web.cfg
@@ -4,7 +4,7 @@ build_file: "repository-gardener/.kokoro/firebase/build-node.sh"
 
 env_vars: {
     key: "DPEBOT_REPO"
-    value: "firebase/friendlychat-web"
+    value: "firebase/codelab-friendlychat-web"
 }
 
 env_vars: {


### PR DESCRIPTION
Update the path to the friendlychat web repo. It is now `codelab-friendlychat-web`. This PR updates to the new path.