### PR TITLE
Use jq to parse versions

### DIFF
--- a/.kokoro/firebase/build-html.sh
+++ b/.kokoro/firebase/build-html.sh
@@ -27,10 +27,10 @@ sudo apt-get install -y jq
 sudo npm install -g npm@latest
 
 # Get latest version of the Firebase SDK on NPM
-FIREBASE_SDK_VER=$(npm view firebase --json | jq '."dist-tags".latest')
+FIREBASE_SDK_VER=$(npm view firebase --json | jq ".\"dist-tags\".latest")
 
 # Get latest version of FirebaseUI on NPM
-FIREBASEUI_VER=$(npm view firebaseui --json | jq '."dist-tags".latest')
+FIREBASEUI_VER=$(npm view firebaseui --json | jq ".\"dist-tags\".latest")
 
 (
 cd repo-to-update

--- a/.kokoro/firebase/build-html.sh
+++ b/.kokoro/firebase/build-html.sh
@@ -27,10 +27,10 @@ sudo apt-get install -y jq
 sudo npm install -g npm@latest
 
 # Get latest version of the Firebase SDK on NPM
-FIREBASE_SDK_VER=$(npm view firebase --json | jq ".\"dist-tags\".latest")
+FIREBASE_SDK_VER=$(npm view firebase --json | jq '.["dist-tags"].latest')
 
 # Get latest version of FirebaseUI on NPM
-FIREBASEUI_VER=$(npm view firebaseui --json | jq ".\"dist-tags\".latest")
+FIREBASEUI_VER=$(npm view firebaseui --json | jq '.["dist-tags"].latest')
 
 (
 cd repo-to-update

--- a/.kokoro/firebase/build-html.sh
+++ b/.kokoro/firebase/build-html.sh
@@ -20,16 +20,17 @@ else
   ./clone-and-checkout.sh -b "${DPEBOT_BRANCH}" "${DPEBOT_REPO}"
 fi
 
+# Get jq
+sudo apt-get install -y jq
+
 # Update npm itself
 sudo npm install -g npm@latest
 
 # Get latest version of the Firebase SDK on NPM
-FIREBASE_SDK_INFO=$(npm view firebase --json)
-FIREBASE_SDK_VER=$(node -e "console.log(${FIREBASE_SDK_INFO}['dist-tags'].latest)")
+FIREBASE_SDK_VER=$(npm view firebase --json | jq '."dist-tags".latest')
 
 # Get latest version of FirebaseUI on NPM
-FIREBASEUI_INFO=$(npm view firebaseui --json)
-FIREBASEUI_VER=$(node -e "console.log(${FIREBASEUI_INFO}['dist-tags'].latest)")
+FIREBASEUI_VER=$(npm view firebaseui --json | jq '."dist-tags".latest')
 
 (
 cd repo-to-update


### PR DESCRIPTION
Some builds have been failing with:
```
github/repository-gardener/.kokoro/firebase/build-html.sh: line 28: /usr/local/bin/node: Argument list too long
```

Local proof that this works:
```bash
VER=$(npm view firebase --json | jq '.["dist-tags"].latest'); echo $VER
"7.12.1"
```

Final proof:
https://g3c.corp.google.com/results/invocations/08045cd3-32a7-47d9-9b5e-9e0216ed642f/targets