### PR TITLE
Use jq "raw" mode

### DIFF
--- a/.kokoro/firebase/build-html.sh
+++ b/.kokoro/firebase/build-html.sh
@@ -27,10 +27,10 @@ sudo apt-get install -y jq
 sudo npm install -g npm@latest
 
 # Get latest version of the Firebase SDK on NPM
-FIREBASE_SDK_VER=$(npm view firebase --json | jq '.["dist-tags"].latest')
+FIREBASE_SDK_VER=$(npm view firebase --json | jq -r '.["dist-tags"].latest')
 
 # Get latest version of FirebaseUI on NPM
-FIREBASEUI_VER=$(npm view firebaseui --json | jq '.["dist-tags"].latest')
+FIREBASEUI_VER=$(npm view firebaseui --json | jq -r '.["dist-tags"].latest')
 
 (
 cd repo-to-update


### PR DESCRIPTION
Otherwise we get something like this:
<img width="1416" alt="Screen Shot 2020-09-29 at 2 05 56 PM" src="https://user-images.githubusercontent.com/8466666/94562194-07a87400-0233-11eb-9d6d-856c7bd72fff.png">

Success:
https://g3c.corp.google.com/results/invocations/20708753-92d8-4ef2-bebe-948068105ec9/targets/cloud-devrel%2Fdpebot%2Ffirebase%2Fsnippets-web-html;config=default/log
