### PR TITLE
Pin npm, install ruby

### DIFF
--- a/.kokoro/firebase/build-html.sh
+++ b/.kokoro/firebase/build-html.sh
@@ -24,7 +24,7 @@ fi
 sudo apt-get install -y jq
 
 # Update npm itself
-sudo npm install -g npm@latest
+sudo npm install -g npm@6.14.11
 
 # Get latest version of the Firebase SDK on NPM
 FIREBASE_SDK_VER=$(npm view firebase --json | jq -r '.["dist-tags"].latest')

--- a/use-latest-deps-ios.sh
+++ b/use-latest-deps-ios.sh
@@ -61,6 +61,7 @@ set -e
 set -x
 
 # Install Ruby
+# shellcheck disable=SC1091
 source /etc/profile.d/rvm.sh
 rvm install 2.3.3
 rvm use 2.3.3

--- a/use-latest-deps-ios.sh
+++ b/use-latest-deps-ios.sh
@@ -61,9 +61,9 @@ set -e
 set -x
 
 # Install Ruby
-sudo apt-get install -y ruby-full
-which ruby
-ruby -v
+source /etc/profile.d/rvm.sh
+rvm install 2.3.3
+rvm use 2.3.3
 
 # Install cocoapods
 gem install --user-install cocoapods

--- a/use-latest-deps-ios.sh
+++ b/use-latest-deps-ios.sh
@@ -60,6 +60,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 set -x
 
+# Install Ruby
+rvm install 2.3.3
+rvm use 2.3.3
+
 # Install cocoapods
 gem install --user-install cocoapods
 

--- a/use-latest-deps-ios.sh
+++ b/use-latest-deps-ios.sh
@@ -61,6 +61,7 @@ set -e
 set -x
 
 # Install Ruby
+source "${HOME}/.rvm/scripts/rvm"
 rvm install 2.3.3
 rvm use 2.3.3
 

--- a/use-latest-deps-ios.sh
+++ b/use-latest-deps-ios.sh
@@ -60,8 +60,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 set -x
 
-# Install Ruby
+# Install RVM
+curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
+curl -sSL https://get.rvm.io | bash -s stable --ruby
 source "${HOME}/.rvm/scripts/rvm"
+
+# Install Ruby
 rvm install 2.3.3
 rvm use 2.3.3
 

--- a/use-latest-deps-ios.sh
+++ b/use-latest-deps-ios.sh
@@ -60,14 +60,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 set -x
 
-# Install RVM
-curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
-curl -sSL https://get.rvm.io | sudo bash -s stable --ruby
-source "${HOME}/.rvm/scripts/rvm"
-
 # Install Ruby
-rvm install 2.3.3
-rvm use 2.3.3
+sudo apt-get install ruby-full
+which ruby
+ruby -v
 
 # Install cocoapods
 gem install --user-install cocoapods

--- a/use-latest-deps-ios.sh
+++ b/use-latest-deps-ios.sh
@@ -61,7 +61,7 @@ set -e
 set -x
 
 # Install Ruby
-sudo apt-get install ruby-full
+sudo apt-get install -y ruby-full
 which ruby
 ruby -v
 

--- a/use-latest-deps-ios.sh
+++ b/use-latest-deps-ios.sh
@@ -62,7 +62,7 @@ set -x
 
 # Install RVM
 curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
-curl -sSL https://get.rvm.io | bash -s stable --ruby
+curl -sSL https://get.rvm.io | sudo bash -s stable --ruby
 source "${HOME}/.rvm/scripts/rvm"
 
 # Install Ruby

--- a/use-latest-deps-node.sh
+++ b/use-latest-deps-node.sh
@@ -93,9 +93,9 @@ node --version
 #  * npm-check-updates: provides the `ncu` tool
 # Tools installed in the parent directory to avoid polluting the repo's 
 # package.json file.
-sudo npm install -g npm@latest
+sudo npm install -g npm@6.14.11
 npm --prefix ../ install npm-check-updates@2.15.0
-npm --prefix ../ install yarn
+npm --prefix ../ install yarn@1.22.10
 
 # Find all package.json files.
 files=$(find . -name "package.json" -not -path "**/node_modules/*")


### PR DESCRIPTION
Reasons:
1. `npm` v7 is now stable which is a breaking change
2. `cocoapods` now requires Ruby 2.3.3+

Fixed:

- Node green build: https://fusion2.corp.google.com/invocations/fbf758a6-71ec-4aa2-adb0-6bf667c7fb6f/targets
- iOS green build: https://fusion2.corp.google.com/invocations/0d958fe3-feae-4d27-becd-ffda7cf4b7cf/targets