### PR TITLE
Fix find -execdir failure

### DIFF
--- a/use-latest-deps-ios.sh
+++ b/use-latest-deps-ios.sh
@@ -59,21 +59,23 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 set -e
 set -x
+set -o pipefail
 
 # Install Ruby
 # shellcheck disable=SC1091
 source /etc/profile.d/rvm.sh
-rvm install 2.3.3
-rvm use 2.3.3
+rvm install 2.6.0
+rvm use 2.6.0
 
-# Install cocoapods
-gem install --user-install cocoapods
-
-# Install and uninstall pods for each Podfile to update Podfile.lock
-find . -iname Podfile -execdir /home/kbuilder/.gem/ruby/2.4.0/bin/pod update \; -execdir /home/kbuilder/.gem/ruby/2.4.0/bin/pod deintegrate \;
+# Install gems
+gem install bundler
+gem install cocoapods
 
 # Find and update each Gemfile.lock
 find . -iname Gemfile.lock -execdir bundle update \;
+
+# Install and uninstall pods for each Podfile to update Podfile.lock
+find . -iname Podfile -execdir pod update \; -execdir pod deintegrate \;
 
 # If there were any changes, test them and then push and send a PR.
 set +e


### PR DESCRIPTION
Previously the pod command executed by `find` was failing, but since `find` swallows errors, it wasn't reported in the fusion UI.

Also updates ruby.