### PR TITLE
use java 11 for Android projects

### DIFF
--- a/.kokoro/firebase/common.cfg
+++ b/.kokoro/firebase/common.cfg
@@ -3,6 +3,9 @@
 # The github token is stored here.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/dpebot"
 
+# Copy a JDK 11 installation from x20
+gfile_resources: "/x20/projects/java-platform/linux-amd64/jdk-11-latest"
+
 # Common env vars for all repositories and builds.
 env_vars: {
     key: "DPEBOT_GITHUB_TOKEN_FILE"

--- a/use-latest-deps-android.sh
+++ b/use-latest-deps-android.sh
@@ -71,6 +71,12 @@ update_dependencies () {
   fi
 }
 
+# Use the version of Java specified in the build config
+export JAVA_HOME=${KOKORO_GFILE_DIR}
+export PATH="$JAVA_HOME/bin:$PATH"
+
+$JAVA_HOME/bin/javac -version
+
 # Check for optional arguments.
 DRYRUN=0
 while getopts :d opt; do

--- a/use-latest-deps-android.sh
+++ b/use-latest-deps-android.sh
@@ -75,8 +75,6 @@ update_dependencies () {
 export JAVA_HOME=${KOKORO_GFILE_DIR}
 export PATH="$JAVA_HOME/bin:$PATH"
 
-$JAVA_HOME/bin/javac -version
-
 # Check for optional arguments.
 DRYRUN=0
 while getopts :d opt; do


### PR DESCRIPTION
Most of Firebase's Android repos now use Gradle 7 which requires Java 11.
This PR should add the required config for dpebot to use jdk11

(Googlers see also: [cl/439864980](http://cl/439864980) )