### PR TITLE
update Android SDK to API level 32

### DIFF
--- a/fix_android_dependencies.py
+++ b/fix_android_dependencies.py
@@ -4,8 +4,8 @@ import re
 
 # These will have to be updated manually over time, there's not an
 # easy way to determine the latest version.
-COMPILE_SDK_VERSION = 31
-TARGET_SDK_VERSION = 31
+COMPILE_SDK_VERSION = 32
+TARGET_SDK_VERSION = 32
 BUILD_TOOLS_VERSION = '30.0.2'
 
 COMPILE_SDK_RE = r'compileSdkVersion[\s][\w]+'


### PR DESCRIPTION
API Level 32 is a feature drop for Android 12 (codenamed [12L](https://developer.android.com/about/versions/12/12L/summary)) which adds support for large screens.
This PR should allow our bot to update Android Projects to API Level 32