### PR TITLE
add missing `fi` to build-node.sh

### DIFF
--- a/.kokoro/firebase/build-node.sh
+++ b/.kokoro/firebase/build-node.sh
@@ -27,10 +27,12 @@ if [ -z ${DPEBOT_NODE_REGEX+x} ]; then
     ../use-latest-deps-node.sh "${DPEBOT_REPO}"
   else
     ../use-latest-deps-node.sh -i "$DPEBOT_FILE_INCLUDE_PATTERN" "${DPEBOT_REPO}"
+  fi
 else
   if [ -z ${DPEBOT_FILE_INCLUDE_PATTERN+x} ]; then
     ../use-latest-deps-node.sh -p "${DPEBOT_NODE_REGEX}" "${DPEBOT_REPO}"
   else
     ../use-latest-deps-node.sh -i "$DPEBOT_FILE_INCLUDE_PATTERN" -p "${DPEBOT_NODE_REGEX}" "${DPEBOT_REPO}"
+  fi
 fi
 )


### PR DESCRIPTION
The nested `if`s introduced in #149 were missing their respective `fi` tokens.
This is causing node builds to error out with the error:

```
.kokoro/firebase/build-node.sh: line 30: syntax error near unexpected token `else'
```

This PR should add the missing `fi`.