### PR TITLE
update Android SDK to API level 33

### DIFF
--- a/fix_android_dependencies.py
+++ b/fix_android_dependencies.py
@@ -4,8 +4,8 @@ import re
 
 # These will have to be updated manually over time, there's not an
 # easy way to determine the latest version.
-COMPILE_SDK_VERSION = 32
-TARGET_SDK_VERSION = 32
+COMPILE_SDK_VERSION = 33
+TARGET_SDK_VERSION = 33
 BUILD_TOOLS_VERSION = '30.0.2'
 
 COMPILE_SDK_RE = r'compileSdkVersion[\s][\w]+'


### PR DESCRIPTION
Althought Android 13 is still in Beta 4, their [timeline](https://developer.android.com/about/versions/13/overview#timeline) indicates that it's already reached platform stability and recommends that apps ands libraries should start releasing compatible versions.

I think it's about time to have our libraries and sample apps updated, before the final release.