### PR TITLE
Migrate from master to main branch in php

### DIFF
--- a/.kokoro/php-docs-samples.cfg
+++ b/.kokoro/php-docs-samples.cfg
@@ -21,3 +21,8 @@ env_vars: {
     key: "DPEBOT_REPO"
     value: "GoogleCloudPlatform/php-docs-samples"
 }
+
+env_vars: {
+    key: "DPEBOT_BRANCH_BASE"
+    value: "main"
+}


### PR DESCRIPTION
The php samples no longer use the master branch and now use the main branch. This should fix the failing builds in kokoro.