### PR TITLE
Use the nox file from python-runtime

### DIFF
--- a/use-latest-deps-python.sh
+++ b/use-latest-deps-python.sh
@@ -66,7 +66,7 @@ set -x
 set -e
 
 pip install --upgrade nox
-nox -s check_requirements -- update
+nox -s check_requirements --noxfile nox.py -- update
 
 
 set +e


### PR DESCRIPTION
This specifies the nox file to match the one listed in GoogleCloudPlatform/python-runtime. Tests have recently been failing in kokoro because the default noxfile (noxfile.py) was unable to be found in the repository.

Noxfile usage
https://nox.thea.codes/en/stable/usage.html#specifying-a-different-configuration-file