### PR TITLE
use JDK 17 in firebase cfg

### DIFF
--- a/.kokoro/firebase/common.cfg
+++ b/.kokoro/firebase/common.cfg
@@ -3,8 +3,8 @@
 # The github token is stored here.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/dpebot"
 
-# Copy a JDK 11 installation from x20
-gfile_resources: "/x20/projects/java-platform/linux-amd64/jdk-11-latest"
+# Copy a JDK 17 installation from x20
+gfile_resources: "/x20/projects/java-platform/linux-amd64/jdk-17-latest"
 
 # Common env vars for all repositories and builds.
 env_vars: {


### PR DESCRIPTION
[Android Gradle Plugin 8.0](https://developer.android.com/studio/preview/features#jdk-17-agp) now requires JDK 17