### PR TITLE
update Android SDK to API level 34

### DIFF
--- a/fix_android_dependencies.py
+++ b/fix_android_dependencies.py
@@ -4,9 +4,9 @@ import re
 
 # These will have to be updated manually over time, there's not an
 # easy way to determine the latest version.
-COMPILE_SDK_VERSION = 33
-TARGET_SDK_VERSION = 33
-BUILD_TOOLS_VERSION = '30.0.2'
+COMPILE_SDK_VERSION = 34
+TARGET_SDK_VERSION = 34
+BUILD_TOOLS_VERSION = '34.0.0'
 
 COMPILE_SDK_RE = r'compileSdk(?:Version)[\s][\w]+'
 TARGET_SDK_RE = r'targetSdk(?:Version)[\s][\w]+'


### PR DESCRIPTION
Now is the perfect time to update to API level 34 since:
- It has reached API stability
- Recent androidx libraries now require compiling with API level 34 (eg. [navigation](https://github.com/firebase/quickstart-android/actions/runs/5849843549/job/15858578772?pr=1520)):
    ```
    Dependency 'androidx.navigation:navigation-fragment:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.
    ```