### PR TITLE
add support for compileSdk written in kts

### DIFF
--- a/fix_android_dependencies.py
+++ b/fix_android_dependencies.py
@@ -8,9 +8,9 @@ COMPILE_SDK_VERSION = 34
 TARGET_SDK_VERSION = 34
 BUILD_TOOLS_VERSION = '34.0.0'
 
-COMPILE_SDK_RE = r'compileSdk(?:Version)[\s][\w]+'
-TARGET_SDK_RE = r'targetSdk(?:Version)[\s][\w]+'
-BUILD_TOOLS_RE = r'buildTools(?:Version)[\s][\'\"\w\.]+'
+COMPILE_SDK_RE = r'compileSdk(?:Version)?\s*=?\s*[\w]+'
+TARGET_SDK_RE = r'targetSdk(?:Version)?\s*=?\s*[\w]+'
+BUILD_TOOLS_RE = r'buildTools(?:Version)?\s*=?\s*[\'\"\w\.]+'
 
 # Depends on https://github.com/ben-manes/gradle-versions-plugin
 #


### PR DESCRIPTION
This should have been done in #167

Before this change:

```grooyv
compileSdk 33 // Recognized ✅
compileSdkVersion 33 // Recognized ✅
compileSdk = 33 // Not recognized ❌
compileSdkVersion = 33 // Not recognized ❌
```

After this change:

```grooyv
compileSdk 33 // Recognized ✅
compileSdkVersion 33 // Recognized ✅
compileSdk = 33 // Recognized ✅
compileSdkVersion = 33 // Recognized ✅
```