### PR TITLE
update Android SDK to API level 35

### DIFF
--- a/fix_android_dependencies.py
+++ b/fix_android_dependencies.py
@@ -4,9 +4,9 @@ import re
 
 # These will have to be updated manually over time, there's not an
 # easy way to determine the latest version.
-COMPILE_SDK_VERSION = 34
-TARGET_SDK_VERSION = 34
-BUILD_TOOLS_VERSION = '34.0.0'
+COMPILE_SDK_VERSION = 35
+TARGET_SDK_VERSION = 35
+BUILD_TOOLS_VERSION = '35.0.0'
 
 # build.gradle(.kts) files
 COMPILE_SDK_RE = r'compileSdk(?:Version)?\s*=?\s*[\w]+'


### PR DESCRIPTION
Android 15 has reached [API stability](https://android-developers.googleblog.com/2024/06/the-third-beta-of-android-15.html) and androidx [now](https://developer.android.com/jetpack/androidx/versions/all-channel#august_7_2024) compiles with API level 35.