### PR TITLE
chore: run gradlew with --no-parallel

### DIFF
--- a/use-latest-deps-android.sh
+++ b/use-latest-deps-android.sh
@@ -32,7 +32,10 @@ generate_dependencies_report () {
     pushd "$dir"
 
     # Generate JSON dependencies report
-    ./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json
+    # TODO: ben-manes/gradle-versions-plugin#948 - Remove '--no-parallel' once this issue
+    #   has been resolved: https://github.com/ben-manes/gradle-versions-plugin/issues/948
+    #   (This is a workaround for Gradle 9.x.x)
+    ./gradlew dependencyUpdates --no-parallel -Drevision=release -DoutputFormatter=json
 
     gradle_exit_code="$?"
 


### PR DESCRIPTION
This is a workaround for Gradle 9.0.0 compatibility. See context in https://github.com/firebase/quickstart-android/pull/2711#issuecomment-3178949915

When I tested this locally, the first build took longer than usual, but subsequent builds were quicker (possibly thanks to caching).