### PR TITLE
chore(android): python 3.8 --> 3.14

### DIFF
--- a/use-latest-deps-android.sh
+++ b/use-latest-deps-android.sh
@@ -57,7 +57,7 @@ update_dependencies () {
     dir=$1
 
     # Activate a virtualenv
-    virtualenv --python python3.8 env
+    virtualenv --python python3.14 env
     # shellcheck disable=SC1091
     source env/bin/activate
 


### PR DESCRIPTION
Python 3.8 has reached EoL in 2024 - this PR should bump our workflow to use Python 3.14 instead (EoL 2030-10)

**Update:** It looks like we're still using Ubuntu 20.04 in our Kokoro build. The latest Ubuntu version currently supported by Kokoro is [22.04](https://g3doc.corp.google.com/devtools/kokoro/g3doc/platforms/configs/containers/ubuntu2204-full_config.md), which comes with Python 3.10 - we should consider migrating to that before bumping the Python version in this PR.