### PR TITLE
chore: fix exit code propagation in use-latest-deps-android.sh

### DIFF
--- a/use-latest-deps-android.sh
+++ b/use-latest-deps-android.sh
@@ -62,8 +62,10 @@ update_dependencies () {
     source env/bin/activate
 
     # Run Android fixer script
+    set +e
     python3 "${dir}/fix_android_dependencies.py"
     python_exit_code="$?"
+    set -e
 
     # Remove the virtualenv
     rm -rf env

--- a/use-latest-deps-android.sh
+++ b/use-latest-deps-android.sh
@@ -63,11 +63,12 @@ update_dependencies () {
 
     # Run Android fixer script
     python3 "${dir}/fix_android_dependencies.py"
+    python_exit_code="$?"
 
     # Remove the virtualenv
     rm -rf env
 
-    return 0
+    return $python_exit_code
   else
     # Return invalid arguments exit code.
     return 128
@@ -133,7 +134,13 @@ if [ $generate_dependencies_report_exit_code -eq 127 ]; then
   for child_dir in "${child_dirs[@]}"
     do
       generate_dependencies_report "${DIR}/${child_dir}"
+      child_exit_code="$?"
+      if [ $child_exit_code -ne 0 ] && [ $child_exit_code -ne 127 ]; then
+        exit $child_exit_code
+      fi
     done
+elif [ $generate_dependencies_report_exit_code -ne 0 ]; then
+  exit $generate_dependencies_report_exit_code
 fi
 
 set -e


### PR DESCRIPTION
@dpebot hasn't updated [firebase/quickstart-android](http://github.com/firebase/quickstart-android) in a while, but the logs in Fusion2 are reporting successful builds, which are false positives because the failures are just being ignored.

This change ensures that failures in either the Gradle `dependencyUpdates` task or the `fix_android_dependencies.py` script are correctly captured and cause the shell script to exit with a non-zero code. 