### PR TITLE
chore(android): remove --no-parallel workaround

### DIFF
--- a/use-latest-deps-android.sh
+++ b/use-latest-deps-android.sh
@@ -32,10 +32,7 @@ generate_dependencies_report () {
     pushd "$dir"
 
     # Generate JSON dependencies report
-    # TODO: ben-manes/gradle-versions-plugin#948 - Remove '--no-parallel' once this issue
-    #   has been resolved: https://github.com/ben-manes/gradle-versions-plugin/issues/948
-    #   (This is a workaround for Gradle 9.x.x)
-    ./gradlew dependencyUpdates --no-parallel -Drevision=release -DoutputFormatter=json
+    ./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json
 
     gradle_exit_code="$?"
 


### PR DESCRIPTION
[gradle-versions-plugin@v0.55.0](https://github.com/ben-manes/gradle-versions-plugin/releases/tag/v0.55.0) dropped the need for `--no-parallel`.

**Update 1:** That version of the plugin failed to publish. I'm following https://github.com/ben-manes/gradle-versions-plugin/issues/997 for updates.

**Update 2:** Version 0.56.0 has been published under a new plugin ID: `com.github.ben-manes.versions` -> `io.github.ben-manes.versions`.

It should be safe to merge this PR once all of our Android repos have updated to the latest version of the plugin (at least 0.56.0):

- [x] [firebase/quickstart-android](https://github.com/firebase/quickstart-android/pull/2819)
- [x] [firebase/snippets-android](https://github.com/firebase/snippets-android/pull/693)
- [x] [firebase/codelab-friendlychat-android](https://github.com/firebase/codelab-friendlychat-android/pull/374)
- [x] [firebase/friendlyeats-android](https://github.com/firebase/friendlyeats-android/pull/298)